### PR TITLE
fix problem that prevented adding knowledge docs

### DIFF
--- a/personate/meta/standard/agents.py
+++ b/personate/meta/standard/agents.py
@@ -195,7 +195,7 @@ class Agent:
             doc = Document.deserialise(filename)
         if not directory:
             directory = self.agent_dir + "/knowledge"
-        elif is_url:
+        if is_url:
             doc = Document.from_url_or_file(
                 source=filename,
                 embedding_model=self.ranker.default_model,


### PR DESCRIPTION
Agents were not adding documents to their knowledge base from reading_list. This was due to a branching error in `add_knowledge`, where the code paths that actually push Documents to the `document_queue` were never reached. 

With this PR, documents are added and accessed by `acrossword` and dumped to the appropriate `knowledge` folder.